### PR TITLE
Fixed monthly RR benchmarks with 0 rain plus melt

### DIFF
--- a/hydrobm/benchmarks.py
+++ b/hydrobm/benchmarks.py
@@ -489,8 +489,7 @@ def monthly_rainfall_runoff_ratio_to_monthly(
     monthly_mean_p = cal_set[precipitation].groupby(cal_set.index.month).mean()
     # Safe calculation: only divide when precipitation > 0, else set 0
     bm_vals = pd.Series(
-        np.where(monthly_mean_p > 0, monthly_mean_q / monthly_mean_p, 0),
-        index=monthly_mean_p.index
+        np.where(monthly_mean_p > 0, monthly_mean_q / monthly_mean_p, 0), index=monthly_mean_p.index
     )  # (at most) 12 rainfall-runoff ratios
     bm_vals = bm_vals.reindex(range(1, 13))  # fill missing months with NaN, does nothing if already 12
     qbm = pd.DataFrame({"bm_monthly_rainfall_runoff_ratio_to_monthly": np.nan}, index=data.index)
@@ -535,8 +534,7 @@ def monthly_rainfall_runoff_ratio_to_daily(data, cal_mask, precipitation="precip
     monthly_mean_p = cal_set[precipitation].groupby(cal_set.index.month).mean()
     # Safe calculation: only divide when precipitation > 0, else set 0
     bm_vals = pd.Series(
-        np.where(monthly_mean_p > 0, monthly_mean_q / monthly_mean_p, 0),
-        index=monthly_mean_p.index
+        np.where(monthly_mean_p > 0, monthly_mean_q / monthly_mean_p, 0), index=monthly_mean_p.index
     )  # (at most) 12 rainfall-runoff ratios
     bm_vals = bm_vals.reindex(range(1, 13))  # fill missing months with NaN, does nothing if already 12
     qbm = pd.DataFrame({"bm_monthly_rainfall_runoff_ratio_to_daily": np.nan}, index=data.index)
@@ -582,8 +580,7 @@ def monthly_rainfall_runoff_ratio_to_timestep(
     monthly_mean_p = cal_set[precipitation].groupby(cal_set.index.month).mean()
     # Safe calculation: only divide when precipitation > 0, else set 0
     bm_vals = pd.Series(
-        np.where(monthly_mean_p > 0, monthly_mean_q / monthly_mean_p, 0),
-        index=monthly_mean_p.index
+        np.where(monthly_mean_p > 0, monthly_mean_q / monthly_mean_p, 0), index=monthly_mean_p.index
     )  # (at most) 12 rainfall-runoff ratios
     bm_vals = bm_vals.reindex(range(1, 13))  # fill missing months with NaN, does nothing if already 12
     qbm = pd.DataFrame(

--- a/hydrobm/tests/test_benchmarks.py
+++ b/hydrobm/tests/test_benchmarks.py
@@ -283,14 +283,16 @@ def test_monthly_rainfall_runoff_ratio_to_monthly():
 
     # Test 3: set precipitation values for January  to 0, should result in no NaN in timeseries,
     # and benchmark flows for January being 0
-    data=create_sines(period=2)
+    data = create_sines(period=2)
     data.loc[data.index.month == 1, "precipitation"] = 0.0
-    cal_mask= data.index
+    cal_mask = data.index
     bm_v, bm_t = create_bm(data, "monthly_rainfall_runoff_ratio_to_monthly", cal_mask)
-    assert not bm_t["bm_monthly_rainfall_runoff_ratio_to_monthly"].isna().any(), \
-        "Failed monthly rainfall-runoff ratio to monthly T3a: found NaN values"
-    assert (bm_t.loc[bm_t.index.month == 1, "bm_monthly_rainfall_runoff_ratio_to_monthly"] == 0).all(), \
-        "Failed monthly rainfall-runoff ratio to monthly T3b: not all January values are 0"
+    assert (
+        not bm_t["bm_monthly_rainfall_runoff_ratio_to_monthly"].isna().any()
+    ), "Failed monthly rainfall-runoff ratio to monthly T3a: found NaN values"
+    assert (
+        bm_t.loc[bm_t.index.month == 1, "bm_monthly_rainfall_runoff_ratio_to_monthly"] == 0
+    ).all(), "Failed monthly rainfall-runoff ratio to monthly T3b: not all January values are 0"
 
 
 def test_monthly_rainfall_runoff_ratio_to_daily():
@@ -324,14 +326,16 @@ def test_monthly_rainfall_runoff_ratio_to_daily():
 
     # Test 3: set precipitation values for January  to 0, should result in no NaN in timeseries,
     # and benchmark flows for January being 0
-    data=create_sines(period=2)
+    data = create_sines(period=2)
     data.loc[data.index.month == 1, "precipitation"] = 0.0
-    cal_mask= data.index
+    cal_mask = data.index
     bm_v, bm_t = create_bm(data, "monthly_rainfall_runoff_ratio_to_monthly", cal_mask)
-    assert not bm_t["bm_monthly_rainfall_runoff_ratio_to_monthly"].isna().any(), \
-        "Failed monthly rainfall-runoff ratio to monthly T3a: found NaN values"
-    assert (bm_t.loc[bm_t.index.month == 1, "bm_monthly_rainfall_runoff_ratio_to_monthly"] == 0).all(), \
-        "Failed monthly rainfall-runoff ratio to monthly T3b: not all January values are 0"
+    assert (
+        not bm_t["bm_monthly_rainfall_runoff_ratio_to_monthly"].isna().any()
+    ), "Failed monthly rainfall-runoff ratio to monthly T3a: found NaN values"
+    assert (
+        bm_t.loc[bm_t.index.month == 1, "bm_monthly_rainfall_runoff_ratio_to_monthly"] == 0
+    ).all(), "Failed monthly rainfall-runoff ratio to monthly T3b: not all January values are 0"
 
 
 def test_monthly_rainfall_runoff_ratio_to_timestep():
@@ -352,14 +356,16 @@ def test_monthly_rainfall_runoff_ratio_to_timestep():
 
     # Test 3: set precipitation values for January  to 0, should result in no NaN in timeseries,
     # and benchmark flows for January being 0
-    data=create_sines(period=2)
+    data = create_sines(period=2)
     data.loc[data.index.month == 1, "precipitation"] = 0.0
-    cal_mask= data.index
+    cal_mask = data.index
     bm_v, bm_t = create_bm(data, "monthly_rainfall_runoff_ratio_to_monthly", cal_mask)
-    assert not bm_t["bm_monthly_rainfall_runoff_ratio_to_monthly"].isna().any(), \
-        "Failed monthly rainfall-runoff ratio to monthly T3a: found NaN values"
-    assert (bm_t.loc[bm_t.index.month == 1, "bm_monthly_rainfall_runoff_ratio_to_monthly"] == 0).all(), \
-        "Failed monthly rainfall-runoff ratio to monthly T3b: not all January values are 0"
+    assert (
+        not bm_t["bm_monthly_rainfall_runoff_ratio_to_monthly"].isna().any()
+    ), "Failed monthly rainfall-runoff ratio to monthly T3a: found NaN values"
+    assert (
+        bm_t.loc[bm_t.index.month == 1, "bm_monthly_rainfall_runoff_ratio_to_monthly"] == 0
+    ).all(), "Failed monthly rainfall-runoff ratio to monthly T3b: not all January values are 0"
 
 
 def test_scaled_precipitation_benchmark():


### PR DESCRIPTION
There was an issue with the monthly rainfall runoff ratio benchmarks in cold regions, where mean monthly rain plus melt could be 0 and cause a division by 0. This pull request addressed this issue by checking if mean monthly precipitation (rain plus melt in cold regions) is 0 and if so, setting the monthly runoff ratio to 0. This may not provide a realistic simulation of streamflow as the corresponding mean monthly flow could still be >0, but it is consistent with the assumption that streamflow is driven by precipitation which is inherent to the rainfall runoff ratio benchmarks. 
I also added tests for the monthly rainfall runoff ratio benchmarks that verify that there are no NaN values in the benchmark timeseries when monthly precipitation is set to 0, and that the benchmark flows are 0 in the months with 0 mean monthly precipitation. 
Also fixed formatting with black.